### PR TITLE
Changed colour of "a" tag

### DIFF
--- a/b829/aberhart/universal/main.css
+++ b/b829/aberhart/universal/main.css
@@ -39,6 +39,21 @@ h3 {
 	font:bold 10pt Verdana, Arial, Helvetica, sans-serif;
 	padding-left:5px;
 }
+a:link {
+    color: #000;
+}
+
+a:visited {
+    color: #000;
+}
+
+a:hover {
+    color: #808080;
+}
+
+a:active {
+    color: #808080;
+}
 .list li {
 	padding:5px;
 }


### PR DESCRIPTION
Black and 50% grey, just like they ask in the visual identity standards. Other than that I didn't really have a reason better than I don't like the blue/purple that's the default