### PR TITLE
Pdf links hack

### DIFF
--- a/b829/aberhart/universal/pdf/build/pdf.js
+++ b/b829/aberhart/universal/pdf/build/pdf.js
@@ -3796,6 +3796,9 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
       
       var linkUrl = this.data.url || '';
       linkUrl = linkUrl.replace(/.*schools.cbe.ab.ca\/b829/, "/b829");
+      if ((linkUrl.search(/b829.*\.pdf/) >= 0) && (linkUrl.search("viewer.html?file=") <  0)) {
+        linkUrl = "/b829/aberhart/universal/pdf/web/viewer.html?file=" + linkUrl;
+      }
       
       var link = document.createElement('a');
       

--- a/b829/aberhart/universal/pdf/build/pdf.js
+++ b/b829/aberhart/universal/pdf/build/pdf.js
@@ -3793,9 +3793,13 @@ var LinkAnnotation = (function LinkAnnotationClosure() {
 
       container.style.borderColor = item.colorCssRgb;
       container.style.borderStyle = 'solid';
-
+      
+      var linkUrl = this.data.url || '';
+      linkUrl = linkUrl.replace(/.*schools.cbe.ab.ca\/b829/, "/b829");
+      
       var link = document.createElement('a');
-      link.href = link.title = this.data.url || '';
+      
+      link.href = link.title = linkUrl;
 
       container.appendChild(link);
 


### PR DESCRIPTION
Sets the pdf wrapper to open any links to our external website (http://schools[...]/b829...) as local links (/b829...), and to modify any links to local pdfs so that they are opened in the wrapper rather than on their own.
All without affecting current functionality.

Primarily implemented to fix #66, but will also prevent similar situations from happening in the future.